### PR TITLE
Sidekiqz2 build integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Vim swap files
+*.swp
+
 # Object files
 *.o
 *.ko

--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,8 @@ buildroot/output/images/rootfs.cpio.gz:
 	@echo device-fw $(VERSION)> $(CURDIR)/buildroot/board/$(TARGET)/VERSIONS
 	@$(foreach dir,$(VSUBDIRS),echo $(dir) $(shell cd $(dir) && git describe --abbrev=4 --dirty --always --tags) >> $(CURDIR)/buildroot/board/$(TARGET)/VERSIONS;)
 	make -C buildroot ARCH=arm zynq_$(TARGET)_defconfig
-	make -C buildroot legal-info
-	scripts/legal_info_html.sh "$(COMPLETE_NAME)" "$(CURDIR)/buildroot/board/$(TARGET)/VERSIONS"
+	ADI_LEGAL=$(ADI_LEGAL) make -C buildroot legal-info
+	ADI_LEGAL=$(ADI_LEGAL) scripts/legal_info_html.sh "$(COMPLETE_NAME)" "$(CURDIR)/buildroot/board/$(TARGET)/VERSIONS"
 	cp build/LICENSE.html buildroot/board/$(TARGET)/msd/LICENSE.html
 	make -C buildroot TOOLCHAIN_EXTERNAL_INSTALL_DIR= ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) BUSYBOX_CONFIG_FILE=$(CURDIR)/buildroot/board/$(TARGET)/busybox-1.25.0.config all
 

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,10 @@ all:
 	@echo "Invalid `TARGET variable ; valid values are: pluto, sidekiqz2" &&
 	exit 1
 else
-all: $(TARGETS) zip-all legal-info
+all: clean-build $(TARGETS) zip-all legal-info
 endif
+
+.NOTPARALLEL: all
 
 TARGET_DTS_FILES:=$(foreach dts,$(TARGET_DTS_FILES),build/$(dts))
 

--- a/scripts/53-adi-plutosdr-usb.rules
+++ b/scripts/53-adi-plutosdr-usb.rules
@@ -1,8 +1,11 @@
 # allow "plugdev" group read/write access to ADI PlutoSDR devices
 # DFU Device
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0456", ATTRS{idProduct}=="b674", MODE="0664", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="2fa2", ATTRS{idProduct}=="5a32", MODE="0664", GROUP="plugdev"
 # SDR Device
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0456", ATTRS{idProduct}=="b673", MODE="0664", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="2fa2", ATTRS{idProduct}=="5a02", MODE="0664", GROUP="plugdev"
 # tell the ModemManager (part of the NetworkManager suite) that the device is not a modem, 
 # and don't send AT commands to it
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0456", ATTRS{idProduct}=="b673", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="2fa2", ATTRS{idProduct}=="5a02", ENV{ID_MM_DEVICE_IGNORE}="1"

--- a/scripts/legal_info_html.sh
+++ b/scripts/legal_info_html.sh
@@ -259,8 +259,9 @@ echo "<div class="boxed">" >> ${FILE}
 html_h2 "Written Offer"
 
 echo "As described above, the firmware included in the ${TARGET} contains copyrighted software that is released and distributed under many licenses, including the GPL.
-A copy of the licenses are included in this file (below).
-You may obtain the complete Corresponding Source code from us for a period of three years after our last shipment of this product, which will be no earlier than 01Jan2021, by sending a money order or check for \$15 (USD) to:
+A copy of the licenses are included in this file (below)." >> ${FILE}
+if [ "$ADI_LEGAL" == "1" ] ; then
+echo "You may obtain the complete Corresponding Source code from us for a period of three years after our last shipment of this product, which will be no earlier than 01Jan2021, by sending a money order or check for \$15 (USD) to:
 <pre>
 GPL Compliance
 Systems Development Group
@@ -276,6 +277,9 @@ Please write “<i>source for the ${TARGET}</i>” in the memo line of your paym
 Since the source does not fit on a DVD-RW, it will be delivered on a USB Thumb drive (hense the higher cost than just DVD or CD).
 <p><b>You will also find a the source on-line, and are encouraged to obtain it for zero cost, at the project web sites.</b></p>
 </div>" >> ${FILE}
+else # not ADI_LEGAL
+echo "Since you, the end user built this from source, for ${TARGET}, and didn't get a binary, there is no requirement for a written offer." >> ${FILE}
+fi
 
 html_h2 "NO WARRANTY"
 

--- a/scripts/pluto.mk
+++ b/scripts/pluto.mk
@@ -1,0 +1,10 @@
+
+# Target specific constants go here
+
+HDF_URL:=http://github.com/analogdevicesinc/plutosdr-fw/releases/download/${LATEST_TAG}/system_top.hdf
+TARGET_DTS_FILES:= zynq-pluto-sdr.dtb zynq-pluto-sdr-revb.dtb zynq-pluto-sdr-revc.dtb
+COMPLETE_NAME:=PlutoSDR
+ZIP_ARCHIVE_PREFIX:=plutosdr
+DEVICE_VID:=0x0456
+DEVICE_PID:=0xb673
+

--- a/scripts/pluto.mk
+++ b/scripts/pluto.mk
@@ -1,6 +1,8 @@
 
 # Target specific constants go here
 
+ADI_LEGAL:=1
+
 HDF_URL:=http://github.com/analogdevicesinc/plutosdr-fw/releases/download/${LATEST_TAG}/system_top.hdf
 TARGET_DTS_FILES:= zynq-pluto-sdr.dtb zynq-pluto-sdr-revb.dtb zynq-pluto-sdr-revc.dtb
 COMPLETE_NAME:=PlutoSDR

--- a/scripts/sidekiqz2.its
+++ b/scripts/sidekiqz2.its
@@ -1,0 +1,174 @@
+/*
+ * U-Boot uImage source file with multiple kernels, ramdisks and FDT blobs
+ * This example makes use of the 'loadables' field
+ */
+
+/*
+ * fdt get addr foo /images/fdt@1 data
+ */
+
+/dts-v1/;
+
+/ {
+	description = "Configuration to load fpga before Kernel";
+	magic = "ITB Sidekiq Z2";
+	#address-cells = <1>;
+	images {
+
+		fdt@1 {
+			description = "zynq-sidekiqz2";
+			data = /incbin/("../build/zynq-sidekiqz2-revb.dtb");
+			type = "flat_dt";
+			arch = "arm";
+			compression = "none";
+		};
+
+		fdt@2 {
+			description = "zynq-sidekiqz2-revb";
+			data = /incbin/("../build/zynq-sidekiqz2-revb.dtb");
+			type = "flat_dt";
+			arch = "arm";
+			compression = "none";
+		};
+
+		fdt@3 {
+			description = "zynq-sidekiqz2-revc";
+			data = /incbin/("../build/zynq-sidekiqz2-revb.dtb");
+			type = "flat_dt";
+			arch = "arm";
+			compression = "none";
+		};
+
+		fpga@1 {
+			description = "FPGA";
+			data = /incbin/("../build/system_top.bit");
+			type = "fpga";
+			arch = "arm";
+			compression = "none";
+			load = <0xF000000>;
+			hash@1 {
+				algo = "md5";
+			};
+		};
+
+		linux_kernel@1 {
+			description = "Linux";
+			data = /incbin/("../build/zImage");
+			type = "kernel";
+			arch = "arm";
+			os = "linux";
+			compression = "none";
+			load = <0x8000>;
+			entry = <0x8000>;
+			hash@1 {
+				algo = "md5";
+			};
+		};
+		ramdisk@1 {
+			description = "Ramdisk";
+			data = /incbin/("../build/rootfs.cpio.gz");
+			type = "ramdisk";
+			arch = "arm";
+			os = "linux";
+			compression = "gzip";
+			hash@1 {
+				algo = "md5";
+			};
+		};
+
+	};
+
+	configurations {
+		default = "config@0";
+		config@0 {
+			description = "Linux with fpga RevA";
+			fdt = "fdt@1";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+		/* all below is currently RevB ! */
+
+		config@1 {
+			description = "Linux with fpga RevB";
+			fdt = "fdt@2";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+		config@2 {
+			description = "Linux with fpga RevB";
+			fdt = "fdt@2";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+		config@3 {
+			description = "Linux with fpga RevB";
+			fdt = "fdt@2";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+		config@4 {
+			description = "Linux with fpga RevB";
+			fdt = "fdt@2";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+		config@5 {
+			description = "Linux with fpga RevB";
+			fdt = "fdt@2";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+		config@6 {
+			description = "Linux with fpga RevB";
+			fdt = "fdt@2";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+
+		config@7 {
+			description = "Linux with fpga RevB";
+			fdt = "fdt@2";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+		config@8 { /* This one is actually RevC */
+			description = "Linux with fpga RevC";
+			fdt = "fdt@3";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+		config@9 { /* This one is actually RevB */
+			description = "Linux with fpga RevB";
+			fdt = "fdt@2";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+
+		config@10 {
+			description = "Linux with fpga RevB";
+			fdt = "fdt@2";
+			kernel = "linux_kernel@1";
+			ramdisk = "ramdisk@1";
+			fpga = "fpga@1";
+		};
+	};
+};

--- a/scripts/sidekiqz2.mk
+++ b/scripts/sidekiqz2.mk
@@ -1,0 +1,7 @@
+
+TARGET_DTS_FILES:= zynq-sidekiqz2-revb.dtb
+COMPLETE_NAME:=SidekiqZ2
+ZIP_ARCHIVE_PREFIX:=sidekiqz2
+DEVICE_VID:=0x2fa2
+DEVICE_PID:=0x5a02
+


### PR DESCRIPTION
This changeset adds support for building SidekiqZ2 firmware images, similarly to PlutoSDR images.

The way it works:
* make - defaults to Pluto
* make TARGET=<target_name> - where <target_name> is `pluto` or `sidekiqz2`

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>