### PR TITLE
scripts/legal_info_html.sh: close omitted div

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,8 @@ buildroot/output/images/rootfs.cpio.gz:
 	@echo device-fw $(VERSION)> $(CURDIR)/buildroot/board/$(TARGET)/VERSIONS
 	@$(foreach dir,$(VSUBDIRS),echo $(dir) $(shell cd $(dir) && git describe --abbrev=4 --dirty --always --tags) >> $(CURDIR)/buildroot/board/$(TARGET)/VERSIONS;)
 	make -C buildroot ARCH=arm zynq_$(TARGET)_defconfig
-	ADI_LEGAL=$(ADI_LEGAL) make -C buildroot legal-info
-	ADI_LEGAL=$(ADI_LEGAL) scripts/legal_info_html.sh "$(COMPLETE_NAME)" "$(CURDIR)/buildroot/board/$(TARGET)/VERSIONS"
+	make -C buildroot legal-info
+	scripts/legal_info_html.sh "$(COMPLETE_NAME)" "$(CURDIR)/buildroot/board/$(TARGET)/VERSIONS"
 	cp build/LICENSE.html buildroot/board/$(TARGET)/msd/LICENSE.html
 	make -C buildroot TOOLCHAIN_EXTERNAL_INSTALL_DIR= ARCH=arm CROSS_COMPILE=$(CROSS_COMPILE) BUSYBOX_CONFIG_FILE=$(CURDIR)/buildroot/board/$(TARGET)/busybox-1.25.0.config all
 

--- a/scripts/legal_info_html.sh
+++ b/scripts/legal_info_html.sh
@@ -278,7 +278,8 @@ Since the source does not fit on a DVD-RW, it will be delivered on a USB Thumb d
 <p><b>You will also find a the source on-line, and are encouraged to obtain it for zero cost, at the project web sites.</b></p>
 </div>" >> ${FILE}
 else # not ADI_LEGAL
-echo "Since you, the end user built this from source, for ${TARGET}, and didn't get a binary, there is no requirement for a written offer." >> ${FILE}
+echo "Since you, the end user built this from source, for ${TARGET}, and didn't get a binary, there is no requirement for a written offer.
+</div>" >> ${FILE}
 fi
 
 html_h2 "NO WARRANTY"

--- a/scripts/legal_info_html.sh
+++ b/scripts/legal_info_html.sh
@@ -260,7 +260,7 @@ html_h2 "Written Offer"
 
 echo "As described above, the firmware included in the ${TARGET} contains copyrighted software that is released and distributed under many licenses, including the GPL.
 A copy of the licenses are included in this file (below)." >> ${FILE}
-if [ "$ADI_LEGAL" == "1" ] ; then
+if [ "$TARGET" == "PlutoSDR" ] ; then
 echo "You may obtain the complete Corresponding Source code from us for a period of three years after our last shipment of this product, which will be no earlier than 01Jan2021, by sending a money order or check for \$15 (USD) to:
 <pre>
 GPL Compliance
@@ -277,7 +277,7 @@ Please write “<i>source for the ${TARGET}</i>” in the memo line of your paym
 Since the source does not fit on a DVD-RW, it will be delivered on a USB Thumb drive (hense the higher cost than just DVD or CD).
 <p><b>You will also find a the source on-line, and are encouraged to obtain it for zero cost, at the project web sites.</b></p>
 </div>" >> ${FILE}
-else # not ADI_LEGAL
+else # not PlutoSDR
 echo "Since you, the end user built this from source, for ${TARGET}, and didn't get a binary, there is no requirement for a written offer.
 </div>" >> ${FILE}
 fi

--- a/scripts/pluto.mk
+++ b/scripts/pluto.mk
@@ -1,8 +1,6 @@
 
 # Target specific constants go here
 
-ADI_LEGAL:=1
-
 HDF_URL:=http://github.com/analogdevicesinc/plutosdr-fw/releases/download/${LATEST_TAG}/system_top.hdf
 TARGET_DTS_FILES:= zynq-pluto-sdr.dtb zynq-pluto-sdr-revb.dtb zynq-pluto-sdr-revc.dtb
 COMPLETE_NAME:=PlutoSDR


### PR DESCRIPTION
During change 36fbc8f0511e6db ("build: parametrize ADI legal info for
`Written Offer`"), an open <div> was left open.
Fixed this.
Validated with https://validator.w3.org/#validate_by_upload

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>