### PR TITLE
build: remove default branch for buildroot submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,6 @@
 [submodule "buildroot"]
 	path = buildroot
 	url = https://github.com/analogdevicesinc/buildroot.git
-	branch = pluto
 [submodule "linux"]
 	path = linux
 	url = https://github.com/analogdevicesinc/linux


### PR DESCRIPTION
This will allow us to change the default branch in the buildroot repo.
The current default branch is `pluto`, but it would be a good idea to
rename it to master.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>