### PR TITLE
[RFC]scripts: pluto.its: Change device tree to RevC

### DIFF
--- a/scripts/pluto.its
+++ b/scripts/pluto.its
@@ -33,7 +33,7 @@
 
 		fdt@3 {
 			description = "zynq-pluto-sdr-revc";
-			data = /incbin/("../build/zynq-pluto-sdr-revb.dtb");
+			data = /incbin/("../build/zynq-pluto-sdr-revc.dtb");
 			type = "flat_dt";
 			arch = "arm";
 			compression = "none";


### PR DESCRIPTION
The option for fdt@3 was still configured to RevB. This has been changed to
point to the correct RevC device tree.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>