### PR TITLE
scripts/legal_info_html: Fix HTTP 301 Moved Permanently issue with li…

### DIFF
--- a/scripts/legal_info_html.sh
+++ b/scripts/legal_info_html.sh
@@ -159,8 +159,13 @@ package_table_items () {
 			# We should use curl's -L, but then we couldn't track things
 			tmp=$(curl -IsS $url)
 			if [ $(echo "$tmp" | head -1 | grep -E "301|302" | wc -l) -gt 0 ] ; then
+				_url=$url
 				url=$(echo "$tmp" | grep -i "Location:" | awk '{print $2}' | sed -e 's/^[ \t]*//;s/[ \t]*$//')
 				url=${url%$'\r'}
+				if [[ $url != http* ]] ; then
+					url=$_url
+					break
+				fi
 			elif [ $(echo "$tmp" | head -1 | grep "404" | wc -l) -gt 0 ] ; then
 				url=$(echo $url | sed 's#/[^/]*$##' )
 			elif [ $(echo "$tmp" | head -1 | grep "200" | wc -l) -gt 0 ] ; then


### PR DESCRIPTION
…bxml2

The script checks for thw presence of the download sources. When checking libxml2 ,HTTP 301 is returned with a relative location/path on the same host. In fact it just complains about a missing '/' in the URL. Assuming the location doesn't contain a protocol stop and validate the original URL.


$ curl -IsS https://download.gnome.org/sources/libxml2/2.10
HTTP/2 301
server: nginx/1.24.0
content-type: text/html
location: /sources/libxml2/2.10/


$ curl -IsS https://download.gnome.org/sources/libxml2/2.10/
HTTP/2 200