### PR TITLE
CI/status_rule: Add edge-case

### DIFF
--- a/CI/status_rule
+++ b/CI/status_rule
@@ -1,10 +1,8 @@
-# Errors
-error /\bError\b/
-error /(?i)no rule to make target/
-error /(?i)command not found/
-
 # Warnings
 warning /^\bWarning\b/
+warning /TOPDIR: command not found/
+warning /BASE_DIR: command not found/
+warning /CONFIG_DIR: command not found/
 warning /(?i)cannot open/
 warning /(?i)cannot create/
 warning /(?i)cannot stat/
@@ -13,3 +11,8 @@ warning /(?i)no such file or directory/
 warning /(?i)permission denied/
 warning /(?i)Failed connect to artifactory.analog.com/
 warning /(?i)unknown error while trying/
+
+# Errors
+error /\bError\b/
+error /(?i)no rule to make target/
+error /(?i)command not found/


### PR DESCRIPTION
Pluto firmware jobs show the following errors:
- TOPDIR: command not found
- BASE_DIR: command not found
- CONFIG_DIR: command not found
 
These shouldn't be treated as errors, since the build finalizes successfully. This commit modifies the `status_rule` file so that they show up as warnings.